### PR TITLE
plugins: Add vaccel version to plugin data

### DIFF
--- a/.github/workflows/check-merged.yml
+++ b/.github/workflows/check-merged.yml
@@ -43,7 +43,7 @@ jobs:
           if [ "${{ github.event.pull_request.merged }}" == "true" ] || \
             [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "The PR was merged - running upload workflows"
-            echo "is_merged=true" >> "$GITHUB_OUTPUT"
+            echo "is-merged=true" >> "$GITHUB_OUTPUT"
           else
             echo "The PR is not merged. Exiting..."
             echo "is-merged=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Checkout default_branch
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
           path:  ${{ steps.set-repo-dirs.outputs.repo-default }}
 

--- a/plugins/exec/vaccel.c
+++ b/plugins/exec/vaccel.c
@@ -203,6 +203,7 @@ static int fini(void)
 }
 
 VACCEL_MODULE(.name = "exec", .version = VACCEL_VERSION,
+	      .vaccel_version = VACCEL_VERSION,
 	      .type = VACCEL_PLUGIN_SOFTWARE | VACCEL_PLUGIN_GENERIC |
 		      VACCEL_PLUGIN_CPU,
 	      .init = init, .fini = fini)

--- a/plugins/mbench/vaccel.c
+++ b/plugins/mbench/vaccel.c
@@ -84,4 +84,8 @@ static int fini(void)
 	return VACCEL_OK;
 }
 
-VACCEL_MODULE(.name = "mbench", .version = "0.1", .init = init, .fini = fini)
+VACCEL_MODULE(.name = "mbench", .version = VACCEL_VERSION,
+	      .vaccel_version = VACCEL_VERSION,
+	      .type = VACCEL_PLUGIN_SOFTWARE | VACCEL_PLUGIN_GENERIC |
+		      VACCEL_PLUGIN_CPU,
+	      .init = init, .fini = fini)

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -750,4 +750,5 @@ static int fini(void)
 }
 
 VACCEL_MODULE(.name = "noop", .version = VACCEL_VERSION,
-	      .type = VACCEL_PLUGIN_DEBUG, .init = init, .fini = fini)
+	      .vaccel_version = VACCEL_VERSION, .type = VACCEL_PLUGIN_DEBUG,
+	      .init = init, .fini = fini)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ add_custom_command(OUTPUT ${CMAKE_SRC_DIR}/src/include/vaccel.h
 		-P ${CMAKE_SOURCE_DIR}/cmake/GenerateGitVersionHeader.cmake
 	DEPENDS
 		${CMAKE_SOURCE_DIR}/src/include/vaccel.h.in
-	COMMENT "Configuring vaccelrt_version"
+	COMMENT "Configuring vaccel_version"
 	VERBATIM)
 
 add_custom_command(OUTPUT ${CMAKE_SRC_DIR}/src/vaccel.h
@@ -47,7 +47,7 @@ add_custom_command(OUTPUT ${CMAKE_SRC_DIR}/src/vaccel.h
 		-P ${CMAKE_SOURCE_DIR}/cmake/GenerateGitVersionHeader.cmake
 	DEPENDS
 		${CMAKE_SOURCE_DIR}/src/vaccel.h.in
-	COMMENT "Configuring vaccelrt_version"
+	COMMENT "Configuring vaccel_version"
 	VERBATIM)
 
 add_custom_target(version ALL

--- a/src/include/plugin.h
+++ b/src/include/plugin.h
@@ -64,8 +64,11 @@ struct vaccel_plugin_info {
 	/* Name of the plugin */
 	const char *name;
 
-	/* human-readable version number */
+	/* Human-readable version number */
 	const char *version;
+
+	/* Human-readable vAccelRT version that the plugin has been built with */
+	const char *vaccel_version;
 
 	/* Plugin initialization function */
 	int (*init)(void);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -17,6 +17,8 @@ size_t get_nr_plugins();
 struct vaccel_plugin *get_virtio_plugin();
 int plugins_bootstrap();
 int plugins_shutdown();
+int parse_plugin_version(int *major, int *minor1, int *minor2, char **extra,
+			 const char *str);
 
 #ifdef __cplusplus
 }

--- a/src/vaccel.c
+++ b/src/vaccel.c
@@ -43,13 +43,18 @@ static int load_backend_plugin(const char *path)
 
 	plugin = *plugin_p;
 	ret = register_plugin(plugin);
-	if (ret != VACCEL_OK)
+	if (ret != VACCEL_OK) {
+		vaccel_error("Could not register plugin %s", path);
 		goto close_dl;
+	}
 
 	/* Initialize the plugin */
 	ret = plugin->info->init();
-	if (ret != VACCEL_OK)
+	if (ret != VACCEL_OK) {
+		vaccel_error("Could not initialize plugin %s",
+			     plugin->info->name);
 		goto close_dl;
+	}
 
 	/* Keep dl handle so we can later close the library */
 	plugin->dl_handle = dl;
@@ -186,7 +191,11 @@ __attribute__((constructor)) static void vaccel_init(void)
 	if (!plugins)
 		return;
 
-	load_backend_plugins(plugins);
+	ret = load_backend_plugins(plugins);
+	if (ret) {
+		vaccel_error("Could not load backend plugins");
+		exit(ret);
+	}
 }
 
 __attribute__((destructor)) static void vaccel_fini(void)


### PR DESCRIPTION
Implement a way to (optionally) verify plugin compatibility with vaccel:
- Add to plugin data the vaccel version that the plugin has been built with (vaccel_version)
- Compare plugin's vaccel version with current vaccelrt version when registering the plugin
- Provide VACCEL_IGNORE_VERSION environment variable to disable the version check at runtime