### PR TITLE
fix: Use plugin regardless of the session hint if it's the only one

### DIFF
--- a/src/plugin.h
+++ b/src/plugin.h
@@ -9,6 +9,7 @@
 
 void *get_plugin_op(enum vaccel_op_type op_type, unsigned int hint);
 int get_available_plugins(enum vaccel_op_type op_type);
-struct vaccel_plugin *get_virtio_plugin(void);
-int plugins_bootstrap(void);
-int plugins_shutdown(void);
+size_t get_nr_plugins();
+struct vaccel_plugin *get_virtio_plugin();
+int plugins_bootstrap();
+int plugins_shutdown();

--- a/src/session.c
+++ b/src/session.c
@@ -273,9 +273,8 @@ int vaccel_sess_init(struct vaccel_session *sess, uint32_t flags)
 	if (!sessions.initialized)
 		return VACCEL_ESESS;
 
-	if (flags & VACCEL_REMOTE) {
-		virtio = get_virtio_plugin();
-
+	virtio = get_virtio_plugin();
+	if ((flags & VACCEL_REMOTE) || (get_nr_plugins() == 1 && virtio)) {
 		if (!virtio) {
 			vaccel_error(
 				"Could not initialize VirtIO session, no VirtIO Plugin loaded yet");
@@ -283,7 +282,6 @@ int vaccel_sess_init(struct vaccel_session *sess, uint32_t flags)
 		}
 
 		ret = virtio->info->sess_init(sess, flags & (~VACCEL_REMOTE));
-
 		if (ret) {
 			vaccel_error("Could not create host-side session");
 			return ret;


### PR DESCRIPTION
Do not fail if a single plugin of virtio type is used and the session flags do not contain VACCEL_REMOTE.