### PR TITLE
ci: Change hardcoded branch in checkout action

### DIFF
--- a/.github/workflows/add-git-trailers.yml
+++ b/.github/workflows/add-git-trailers.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         uses: ./.github/actions/initialize-workspace

--- a/.github/workflows/check-merged.yml
+++ b/.github/workflows/check-merged.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         uses: ./.github/actions/initialize-workspace

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         uses: ./.github/actions/initialize-workspace

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace
@@ -94,7 +94,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace
@@ -163,7 +163,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace

--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace
@@ -49,7 +49,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace
@@ -74,7 +74,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'ci_rework_plugin') || '' }}
+          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
 
       - name: Initialize workspace
         id: initialize_workspace


### PR DESCRIPTION
Change vaccel branch that is checked out in reusable workflows when called from external repos. Should be 'main' but the previous PR's branch was used instead.