### PR TITLE
ci: Allow setting the runner archs

### DIFF
--- a/.github/actions/commit-file/action.yml
+++ b/.github/actions/commit-file/action.yml
@@ -18,7 +18,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Verify file changed
+      id: verify_file_changed
+      working-directory: ${{ inputs.workdir }}
+      run: |
+        RES=0
+        git diff --quiet ${{ inputs.file }} || RES="$?"
+        [ "$RES" != 0 ] && [ "$RES" != 1 ] && exit "$((RES + 0))"
+        echo "changed=${RES}" >> "$GITHUB_OUTPUT"
+        echo "changed=${RES}"
+      shell: bash
+
     - name: Commit file
+      if: ${{ steps.verify_file_changed.changed == 1 }}
       working-directory: ${{ inputs.workdir }}
       run: |
         CONTENT=$(base64 -i "${{ inputs.file }}")

--- a/.github/actions/readd-issue-label/action.yml
+++ b/.github/actions/readd-issue-label/action.yml
@@ -14,6 +14,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - run: sleep 3
+      shell: bash
+
     - name: Remove label
       run: |
         curl -L \

--- a/.github/workflows/add-git-trailers.yml
+++ b/.github/workflows/add-git-trailers.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   git-trailers:
-    name: Add Git Trailers to PR commits
+    name: Add Git Trailers
     runs-on: [self-hosted, x86_64]
     permissions:
       contents: write

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -6,6 +6,9 @@ on:
       runner:
         type: string
         default: '["gcc", "lite", "2204"]'
+      runner-arch:
+        type: string
+        default: 'x86_64'
       options:
         type: string
         default: 'auto_features=enabled'
@@ -25,7 +28,7 @@ on:
 jobs:
   coverage_report:
     name: Coverage Report
-    runs-on: [self-hosted, x86_64, "${{ fromJSON(inputs.runner) }}"]
+    runs-on: [self-hosted, "${{ inputs.runner-arch }}", "${{ fromJSON(inputs.runner) }}"]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -20,6 +20,6 @@ jobs:
   git_trailers:
     needs: [commit_coverage]
     name: Add Git Trailers to PR commits
-    if: ${{ github.event.review.state == 'approved' }}
+    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.review.state == 'approved' }}
     uses: ./.github/workflows/add-git-trailers.yml
     secrets: inherit

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,6 +6,9 @@ on:
       runner:
         type: string
         default: '["gcc", "lite", "2204"]'
+      runner-archs:
+        type: string
+        default: '["x86_64", "aarch64", "armv7l"]'
       options:
         type: string
         default: 'auto_features=enabled'
@@ -30,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        archconfig: [x86_64, aarch64, armv7l]
+        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
         build_type: [debug, release]
       fail-fast: false
 

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -6,6 +6,9 @@ on:
       runner:
         type: string
         default: '["gcc", "lite", "2204"]'
+      runner-arch:
+        type: string
+        default: 'x86_64'
       options:
         type: string
         default: 'auto_features=enabled'
@@ -23,7 +26,7 @@ on:
 jobs:
   linter_cppcheck:
     name: Lint C/C++ (cppcheck)
-    runs-on: [self-hosted, x86_64, "${{ fromJSON(inputs.runner) }}"]
+    runs-on: [self-hosted, "${{ inputs.runner-arch }}", "${{ fromJSON(inputs.runner) }}"]
 
     env:
       CC: gcc-12

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -181,6 +181,7 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: false
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_PYTHON_RUFF: true
           VALIDATE_BASH: true

--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -6,6 +6,9 @@ on:
       runner:
         type: string
         default: '["gcc", "lite", "2204"]'
+      runner-arch:
+        type: string
+        default: 'x86_64'
       plugin:
         type: string
         default: ''
@@ -16,7 +19,7 @@ on:
 jobs:
   linter_commitlint:
     name: Lint Commit Messages
-    runs-on: [self-hosted, x86_64, "${{ fromJSON(inputs.runner) }}"]
+    runs-on: [self-hosted, "${{ inputs.runner-arch }}", "${{ fromJSON(inputs.runner) }}"]
 
     steps:
       - name: Checkout .github directory

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -15,6 +15,9 @@ on:
       dist-options:
         type: string
         default: ''
+      skip-examples:
+        type: boolean
+        default: false
       valgrind:
         type: boolean
         default: true
@@ -85,14 +88,14 @@ jobs:
           install: 'true'
 
       - name: Run examples
-        if: ${{ inputs.release == false }}
+        if: ${{ inputs.skip-examples == false && inputs.release == false }}
         uses: ./.github/actions/run-examples
         with:
           prefix: ${{github.workspace}}/artifacts/${{matrix.archconfig}}/${{matrix.build_type}}/opt
           plugin: ${{ inputs.plugin }}
 
       - name: Run examples with valgrind
-        if: ${{ inputs.release == false && inputs.valgrind == true}}
+        if: ${{ inputs.skip-examples == false && inputs.release == false && inputs.valgrind == true }}
         uses: ./.github/actions/run-examples
         with:
           prefix: ${{github.workspace}}/artifacts/${{matrix.archconfig}}/${{matrix.build_type}}/opt

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -6,6 +6,9 @@ on:
       runner:
         type: string
         default: '["gcc", "lite", "2204"]'
+      runner-archs:
+        type: string
+        default: '["x86_64", "aarch64", "armv7l"]'
       options:
         type: string
         default: 'auto_features=enabled'
@@ -36,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        archconfig: [x86_64, aarch64, armv7l]
+        archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
         build_type: [debug, release]
       fail-fast: false
 


### PR DESCRIPTION
Add option to set the runner architectures for reusable workflows that
rely on specific runners