### PR TITLE
ci(trailers): Fix trailers workflow for dependabot commits

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -2,6 +2,9 @@ users:
   github-actions:
     name: github-actions[bot]
     email: 41898282+github-actions[bot]@users.noreply.github.com
+  dependabot:
+    name: dependabot[bot]
+    email: support@github.com
   ananos:
     name: Anastassios Nanos
     email: ananos@nubificus.co.uk

--- a/.github/workflows/add-git-trailers.yml
+++ b/.github/workflows/add-git-trailers.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   git-trailers:
     name: Add Git Trailers
-    runs-on: [self-hosted, x86_64]
+    runs-on: [self-hosted, x86_64, "2204"]
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Add dependabot to contributors.yaml and only use compatible runners for the add-git-trailers workflow