### PR TITLE
Fix torch inference example

### DIFF
--- a/.github/actions/initialize-workspace/action.yml
+++ b/.github/actions/initialize-workspace/action.yml
@@ -68,3 +68,15 @@ runs:
         cp -rn .github/remote-actions-repo/.github ./
         rm -rf .github/remote-actions-repo
       shell: bash
+
+    - name: Load scripts' variables
+      run: |
+        SCRIPTS_DIR=${{ github.workspace }}/scripts
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
+        SCRIPTS_CONFIG_VARIABLES=${SCRIPTS_DIR}/config/variables.env
+        [ ! -f "${SCRIPTS_CONFIG_VARIABLES}" ] && exit 0
+        source "${SCRIPTS_CONFIG_VARIABLES}"
+        while IFS= read -r line; do
+          eval "echo $line" >> "$GITHUB_ENV"
+        done < "${SCRIPTS_CONFIG_VARIABLES}"
+      shell: bash

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Run tests
       id: run-tests
       working-directory: ${{ inputs.source-path }}
-      run: meson test --print-errorlogs -C ${{ inputs.build-path }}
+      run: meson test --print-errorlogs -C "${{ inputs.build-path }}"
       shell: bash
 
     - name: Run tests with valgrind
@@ -27,15 +27,11 @@ runs:
       working-directory: ${{ inputs.source-path }}
       if: ${{ inputs.valgrind == 'true' }}
       run: |
-          valgrind_cmd="valgrind"
-          valgrind_cmd+=" --leak-check=full --show-leak-kinds=all"
-          valgrind_cmd+=" --track-origins=yes --errors-for-leak-kinds=all"
-          valgrind_cmd+=" --max-stackframe=3150000 --error-exitcode=1"
           meson test \
-            --wrap="$valgrind_cmd" \
-            -t 6 \
+            --wrap="${{ env.SCRIPTS_VALGRIND_CMD }}" \
+            -t 7 \
             --print-errorlogs \
-            -C ${{ inputs.build-path }}
+            -C "${{ inputs.build-path }}"
       shell: bash
 
     - name: Calculate coverage

--- a/.github/linters/licenserc.yml
+++ b/.github/linters/licenserc.yml
@@ -34,6 +34,7 @@ header:
     - 'third-party'
     - 'build*'
     - 'examples/input'
+    - 'examples/labels'
     - 'fff.h'
     - 'catch.hpp'
 

--- a/.github/linters/typos.toml
+++ b/.github/linters/typos.toml
@@ -8,5 +8,6 @@ extend-exclude = [
   "subprojects/*",
   "third-party/*",
   "test/catch2/*",
-  "test/fff/*"
+  "test/fff/*",
+  "examples/labels/*"
 ]

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -76,6 +76,13 @@ jobs:
           local-path: ${{ env.DOWNLOAD_PATH }}
           install: 'true'
 
+      # FIXME: Temp
+      - name: Install libcurl & stb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libstb-dev
+        shell: bash
+
       - name: Build project
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -102,6 +102,13 @@ jobs:
           local-path: ${{ env.DOWNLOAD_PATH }}
           install: 'true'
 
+      # FIXME: Temp
+      - name: Install libcurl & stb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libstb-dev
+        shell: bash
+
       - name: Build project
         if: ${{ inputs.release == false }}
         uses: ./.github/actions/build

--- a/examples/labels/imagenet.txt
+++ b/examples/labels/imagenet.txt
@@ -1,0 +1,1000 @@
+tench, Tinca tinca
+goldfish, Carassius auratus
+great white shark, white shark, man-eater, man-eating shark
+tiger shark, Galeocerdo cuvieri
+hammerhead, hammerhead shark
+electric ray, crampfish, numbfish, torpedo
+stingray
+cock
+hen
+ostrich, Struthio camelus
+brambling, Fringilla montifringilla
+goldfinch, Carduelis carduelis
+house finch, linnet, Carpodacus mexicanus
+junco, snowbird
+indigo bunting, indigo finch, indigo bird, Passerina cyanea
+robin, American robin, Turdus migratorius
+bulbul
+jay
+magpie
+chickadee
+water ouzel, dipper
+kite
+bald eagle, American eagle, Haliaeetus leucocephalus
+vulture
+great grey owl, great gray owl, Strix nebulosa
+European fire salamander, Salamandra salamandra
+common newt, Triturus vulgaris
+eft
+spotted salamander, Ambystoma maculatum
+axolotl, mud puppy, Ambystoma mexicanum
+bullfrog, Rana catesbeiana
+tree frog, tree-frog
+tailed frog, bell toad, ribbed toad, tailed toad, Ascaphus trui
+loggerhead, loggerhead turtle, Caretta caretta
+leatherback turtle, leatherback, leathery turtle, Dermochelys coriacea
+mud turtle
+terrapin
+box turtle, box tortoise
+banded gecko
+common iguana, iguana, Iguana iguana
+American chameleon, anole, Anolis carolinensis
+whiptail, whiptail lizard
+agama
+frilled lizard, Chlamydosaurus kingi
+alligator lizard
+Gila monster, Heloderma suspectum
+green lizard, Lacerta viridis
+African chameleon, Chamaeleo chamaeleon
+Komodo dragon, Komodo lizard, dragon lizard, giant lizard
+African crocodile, Nile crocodile, Crocodylus niloticus
+American alligator, Alligator mississipiensis
+triceratops
+thunder snake, worm snake, Carphophis amoenus
+ringneck snake, ring-necked snake, ring snake
+hognose snake, puff adder, sand viper
+green snake, grass snake
+king snake, kingsnake
+garter snake, grass snake
+water snake
+vine snake
+night snake, Hypsiglena torquata
+boa constrictor, Constrictor constrictor
+rock python, rock snake, Python sebae
+Indian cobra, Naja naja
+green mamba
+sea snake
+horned viper, cerastes, sand viper, horned asp, Cerastes cornutus
+diamondback, diamondback rattlesnake, Crotalus adamanteus
+sidewinder, horned rattlesnake, Crotalus cerastes
+trilobite
+harvestman, daddy longlegs, Phalangium opilio
+scorpion
+black and gold garden spider, Argiope aurantia
+barn spider, Araneus cavaticus
+garden spider, Aranea diademata
+black widow, Latrodectus mactans
+tarantula
+wolf spider, hunting spider
+tick
+centipede
+black grouse
+ptarmigan
+ruffed grouse, partridge, Bonasa umbellus
+prairie chicken, prairie grouse, prairie fowl
+peacock
+quail
+partridge
+African grey, African gray, Psittacus erithacus
+macaw
+sulphur-crested cockatoo, Kakatoe galerita, Cacatua galerita
+lorikeet
+coucal
+bee eater
+hornbill
+hummingbird
+jacamar
+toucan
+drake
+red-breasted merganser, Mergus serrator
+goose
+black swan, Cygnus atratus
+tusker
+echidna, spiny anteater, anteater
+platypus, duckbill, duckbilled platypus, duck-billed platypus
+wallaby, brush kangaroo
+koala, koala bear, kangaroo bear, native bear
+wombat
+jellyfish
+sea anemone, anemone
+brain coral
+flatworm, platyhelminth
+nematode, nematode worm, roundworm
+conch
+snail
+slug
+sea slug, nudibranch
+chiton, coat-of-mail shell, sea cradle, polyplacophore
+chambered nautilus, pearly nautilus, nautilus
+Dungeness crab, Cancer magister
+rock crab, Cancer irroratus
+fiddler crab
+king crab, Alaska crab, Alaskan king crab, Alaska king crab
+American lobster, Northern lobster, Maine lobster, Homarus americanus
+spiny lobster, langouste, rock lobster, crawfish, crayfish, sea crawfish
+crayfish, crawfish, crawdad, crawdaddy
+hermit crab
+isopod
+white stork, Ciconia ciconia
+black stork, Ciconia nigra
+spoonbill
+flamingo
+little blue heron, Egretta caerulea
+American egret, great white heron, Egretta albus
+bittern
+crane
+limpkin, Aramus pictus
+European gallinule, Porphyrio porphyrio
+American coot, marsh hen, mud hen, water hen, Fulica americana
+bustard
+ruddy turnstone, Arenaria interpres
+red-backed sandpiper, dunlin, Erolia alpina
+redshank, Tringa totanus
+dowitcher
+oystercatcher, oyster catcher
+pelican
+king penguin, Aptenodytes patagonica
+albatross, mollymawk
+grey whale, gray whale, devilfish, Eschrichtius gibbosus
+killer whale, killer, orca, grampus, sea wolf, Orcinus orca
+dugong, Dugong dugon
+sea lion
+Chihuahua
+Japanese spaniel
+Maltese dog, Maltese terrier, Maltese
+Pekinese, Pekingese, Peke
+Shih-Tzu
+Blenheim spaniel
+papillon
+toy terrier
+Rhodesian ridgeback
+Afghan hound, Afghan
+basset, basset hound
+beagle
+bloodhound, sleuthhound
+bluetick
+black-and-tan coonhound
+Walker hound, Walker foxhound
+English foxhound
+redbone
+borzoi, Russian wolfhound
+Irish wolfhound
+Italian greyhound
+whippet
+Ibizan hound, Ibizan Podenco
+Norwegian elkhound, elkhound
+otterhound, otter hound
+Saluki, gazelle hound
+Scottish deerhound, deerhound
+Weimaraner
+Staffordshire bullterrier, Staffordshire bull terrier
+American Staffordshire terrier, Staffordshire terrier
+Bedlington terrier
+Border terrier
+Kerry blue terrier
+Irish terrier
+Norfolk terrier
+Norwich terrier
+Yorkshire terrier
+wire-haired fox terrier
+Lakeland terrier
+Sealyham terrier, Sealyham
+Airedale, Airedale terrier
+cairn, cairn terrier
+Australian terrier
+Dandie Dinmont, Dandie Dinmont terrier
+Boston bull, Boston terrier
+miniature schnauzer
+giant schnauzer
+standard schnauzer
+Scotch terrier, Scottish terrier, Scottie
+Tibetan terrier, chrysanthemum dog
+silky terrier, Sydney silky
+soft-coated wheaten terrier
+West Highland white terrier
+Lhasa, Lhasa apso
+flat-coated retriever
+curly-coated retriever
+golden retriever
+Labrador retriever
+Chesapeake Bay retriever
+German short-haired pointer
+vizsla, Hungarian pointer
+English setter
+Irish setter, red setter
+Gordon setter
+Brittany spaniel
+clumber, clumber spaniel
+English springer, English springer spaniel
+Welsh springer spaniel
+cocker spaniel, English cocker spaniel, cocker
+Sussex spaniel
+Irish water spaniel
+kuvasz
+schipperke
+groenendael
+malinois
+briard
+kelpie
+komondor
+Old English sheepdog, bobtail
+Shetland sheepdog, Shetland sheep dog, Shetland
+collie
+Border collie
+Bouvier des Flandres, Bouviers des Flandres
+Rottweiler
+German shepherd, German shepherd dog, German police dog, alsatian
+Doberman, Doberman pinscher
+miniature pinscher
+Greater Swiss Mountain dog
+Bernese mountain dog
+Appenzeller
+EntleBucher
+boxer
+bull mastiff
+Tibetan mastiff
+French bulldog
+Great Dane
+Saint Bernard, St Bernard
+Eskimo dog, husky
+malamute, malemute, Alaskan malamute
+Siberian husky
+dalmatian, coach dog, carriage dog
+affenpinscher, monkey pinscher, monkey dog
+basenji
+pug, pug-dog
+Leonberg
+Newfoundland, Newfoundland dog
+Great Pyrenees
+Samoyed, Samoyede
+Pomeranian
+chow, chow chow
+keeshond
+Brabancon griffon
+Pembroke, Pembroke Welsh corgi
+Cardigan, Cardigan Welsh corgi
+toy poodle
+miniature poodle
+standard poodle
+Mexican hairless
+timber wolf, grey wolf, gray wolf, Canis lupus
+white wolf, Arctic wolf, Canis lupus tundrarum
+red wolf, maned wolf, Canis rufus, Canis niger
+coyote, prairie wolf, brush wolf, Canis latrans
+dingo, warrigal, warragal, Canis dingo
+dhole, Cuon alpinus
+African hunting dog, hyena dog, Cape hunting dog, Lycaon pictus
+hyena, hyaena
+red fox, Vulpes vulpes
+kit fox, Vulpes macrotis
+Arctic fox, white fox, Alopex lagopus
+grey fox, gray fox, Urocyon cinereoargenteus
+tabby, tabby cat
+tiger cat
+Persian cat
+Siamese cat, Siamese
+Egyptian cat
+cougar, puma, catamount, mountain lion, painter, panther, Felis concolor
+lynx, catamount
+leopard, Panthera pardus
+snow leopard, ounce, Panthera uncia
+jaguar, panther, Panthera onca, Felis onca
+lion, king of beasts, Panthera leo
+tiger, Panthera tigris
+cheetah, chetah, Acinonyx jubatus
+brown bear, bruin, Ursus arctos
+American black bear, black bear, Ursus americanus, Euarctos americanus
+ice bear, polar bear, Ursus Maritimus, Thalarctos maritimus
+sloth bear, Melursus ursinus, Ursus ursinus
+mongoose
+meerkat, mierkat
+tiger beetle
+ladybug, ladybeetle, lady beetle, ladybird, ladybird beetle
+ground beetle, carabid beetle
+long-horned beetle, longicorn, longicorn beetle
+leaf beetle, chrysomelid
+dung beetle
+rhinoceros beetle
+weevil
+fly
+bee
+ant, emmet, pismire
+grasshopper, hopper
+cricket
+walking stick, walkingstick, stick insect
+cockroach, roach
+mantis, mantid
+cicada, cicala
+leafhopper
+lacewing, lacewing fly
+dragonfly, darning needle, devil's darning needle, sewing needle, snake feeder, snake doctor
+damselfly
+admiral
+ringlet, ringlet butterfly
+monarch, monarch butterfly, milkweed butterfly, Danaus plexippus
+cabbage butterfly
+sulphur butterfly, sulfur butterfly
+lycaenid, lycaenid butterfly
+starfish, sea star
+sea urchin
+sea cucumber, holothurian
+wood rabbit, cottontail, cottontail rabbit
+hare
+Angora, Angora rabbit
+hamster
+porcupine, hedgehog
+fox squirrel, eastern fox squirrel, Sciurus niger
+marmot
+beaver
+guinea pig, Cavia cobaya
+sorrel
+zebra
+hog, pig, grunter, squealer, Sus scrofa
+wild boar, boar, Sus scrofa
+warthog
+hippopotamus, hippo, river horse, Hippopotamus amphibius
+ox
+water buffalo, water ox, Asiatic buffalo, Bubalus bubalis
+bison
+ram, tup
+bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis
+ibex, Capra ibex
+hartebeest
+impala, Aepyceros melampus
+gazelle
+Arabian camel, dromedary, Camelus dromedarius
+llama
+weasel
+mink
+polecat, fitch, foulmart, foumart, Mustela putorius
+black-footed ferret, ferret, Mustela nigripes
+otter
+skunk, polecat, wood pussy
+badger
+armadillo
+three-toed sloth, ai, Bradypus tridactylus
+orangutan, orang, orangutang, Pongo pygmaeus
+gorilla, Gorilla gorilla
+chimpanzee, chimp, Pan troglodytes
+gibbon, Hylobates lar
+siamang, Hylobates syndactylus, Symphalangus syndactylus
+guenon, guenon monkey
+patas, hussar monkey, Erythrocebus patas
+baboon
+macaque
+langur
+colobus, colobus monkey
+proboscis monkey, Nasalis larvatus
+marmoset
+capuchin, ringtail, Cebus capucinus
+howler monkey, howler
+titi, titi monkey
+spider monkey, Ateles geoffroyi
+squirrel monkey, Saimiri sciureus
+Madagascar cat, ring-tailed lemur, Lemur catta
+indri, indris, Indri indri, Indri brevicaudatus
+Indian elephant, Elephas maximus
+African elephant, Loxodonta africana
+lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens
+giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca
+barracouta, snoek
+eel
+coho, cohoe, coho salmon, blue jack, silver salmon, Oncorhynchus kisutch
+rock beauty, Holocanthus tricolor
+anemone fish
+sturgeon
+gar, garfish, garpike, billfish, Lepisosteus osseus
+lionfish
+puffer, pufferfish, blowfish, globefish
+abacus
+abaya
+academic gown, academic robe, judge's robe
+accordion, piano accordion, squeeze box
+acoustic guitar
+aircraft carrier, carrier, flattop, attack aircraft carrier
+airliner
+airship, dirigible
+altar
+ambulance
+amphibian, amphibious vehicle
+analog clock
+apiary, bee house
+apron
+ashcan, trash can, garbage can, wastebin, ash bin, ash-bin, ashbin, dustbin, trash barrel, trash bin
+assault rifle, assault gun
+backpack, back pack, knapsack, packsack, rucksack, haversack
+bakery, bakeshop, bakehouse
+balance beam, beam
+balloon
+ballpoint, ballpoint pen, ballpen, Biro
+Band Aid
+banjo
+bannister, banister, balustrade, balusters, handrail
+barbell
+barber chair
+barbershop
+barn
+barometer
+barrel, cask
+barrow, garden cart, lawn cart, wheelbarrow
+baseball
+basketball
+bassinet
+bassoon
+bathing cap, swimming cap
+bath towel
+bathtub, bathing tub, bath, tub
+beach wagon, station wagon, wagon, estate car, beach waggon, station waggon, waggon
+beacon, lighthouse, beacon light, pharos
+beaker
+bearskin, busby, shako
+beer bottle
+beer glass
+bell cote, bell cot
+bib
+bicycle-built-for-two, tandem bicycle, tandem
+bikini, two-piece
+binder, ring-binder
+binoculars, field glasses, opera glasses
+birdhouse
+boathouse
+bobsled, bobsleigh, bob
+bolo tie, bolo, bola tie, bola
+bonnet, poke bonnet
+bookcase
+bookshop, bookstore, bookstall
+bottlecap
+bow
+bow tie, bow-tie, bowtie
+brass, memorial tablet, plaque
+brassiere, bra, bandeau
+breakwater, groin, groyne, mole, bulwark, seawall, jetty
+breastplate, aegis, egis
+broom
+bucket, pail
+buckle
+bulletproof vest
+bullet train, bullet
+butcher shop, meat market
+cab, hack, taxi, taxicab
+caldron, cauldron
+candle, taper, wax light
+cannon
+canoe
+can opener, tin opener
+cardigan
+car mirror
+carousel, carrousel, merry-go-round, roundabout, whirligig
+carpenter's kit, tool kit
+carton
+car wheel
+cash machine, cash dispenser, automated teller machine, automatic teller machine, automated teller, automatic teller, ATM
+cassette
+cassette player
+castle
+catamaran
+CD player
+cello, violoncello
+cellular telephone, cellular phone, cellphone, cell, mobile phone
+chain
+chainlink fence
+chain mail, ring mail, mail, chain armor, chain armour, ring armor, ring armour
+chain saw, chainsaw
+chest
+chiffonier, commode
+chime, bell, gong
+china cabinet, china closet
+Christmas stocking
+church, church building
+cinema, movie theater, movie theatre, movie house, picture palace
+cleaver, meat cleaver, chopper
+cliff dwelling
+cloak
+clog, geta, patten, sabot
+cocktail shaker
+coffee mug
+coffeepot
+coil, spiral, volute, whorl, helix
+combination lock
+computer keyboard, keypad
+confectionery, confectionary, candy store
+container ship, containership, container vessel
+convertible
+corkscrew, bottle screw
+cornet, horn, trumpet, trump
+cowboy boot
+cowboy hat, ten-gallon hat
+cradle
+crane
+crash helmet
+crate
+crib, cot
+Crock Pot
+croquet ball
+crutch
+cuirass
+dam, dike, dyke
+desk
+desktop computer
+dial telephone, dial phone
+diaper, nappy, napkin
+digital clock
+digital watch
+dining table, board
+dishrag, dishcloth
+dishwasher, dish washer, dishwashing machine
+disk brake, disc brake
+dock, dockage, docking facility
+dogsled, dog sled, dog sleigh
+dome
+doormat, welcome mat
+drilling platform, offshore rig
+drum, membranophone, tympan
+drumstick
+dumbbell
+Dutch oven
+electric fan, blower
+electric guitar
+electric locomotive
+entertainment center
+envelope
+espresso maker
+face powder
+feather boa, boa
+file, file cabinet, filing cabinet
+fireboat
+fire engine, fire truck
+fire screen, fireguard
+flagpole, flagstaff
+flute, transverse flute
+folding chair
+football helmet
+forklift
+fountain
+fountain pen
+four-poster
+freight car
+French horn, horn
+frying pan, frypan, skillet
+fur coat
+garbage truck, dustcart
+gasmask, respirator, gas helmet
+gas pump, gasoline pump, petrol pump, island dispenser
+goblet
+go-kart
+golf ball
+golfcart, golf cart
+gondola
+gong, tam-tam
+gown
+grand piano, grand
+greenhouse, nursery, glasshouse
+grille, radiator grille
+grocery store, grocery, food market, market
+guillotine
+hair slide
+hair spray
+half track
+hammer
+hamper
+hand blower, blow dryer, blow drier, hair dryer, hair drier
+hand-held computer, hand-held microcomputer
+handkerchief, hankie, hanky, hankey
+hard disc, hard disk, fixed disk
+harmonica, mouth organ, harp, mouth harp
+harp
+harvester, reaper
+hatchet
+holster
+home theater, home theatre
+honeycomb
+hook, claw
+hoopskirt, crinoline
+horizontal bar, high bar
+horse cart, horse-cart
+hourglass
+iPod
+iron, smoothing iron
+jack-o'-lantern
+jean, blue jean, denim
+jeep, landrover
+jersey, T-shirt, tee shirt
+jigsaw puzzle
+jinrikisha, ricksha, rickshaw
+joystick
+kimono
+knee pad
+knot
+lab coat, laboratory coat
+ladle
+lampshade, lamp shade
+laptop, laptop computer
+lawn mower, mower
+lens cap, lens cover
+letter opener, paper knife, paperknife
+library
+lifeboat
+lighter, light, igniter, ignitor
+limousine, limo
+liner, ocean liner
+lipstick, lip rouge
+Loafer
+lotion
+loudspeaker, speaker, speaker unit, loudspeaker system, speaker system
+loupe, jeweler's loupe
+lumbermill, sawmill
+magnetic compass
+mailbag, postbag
+mailbox, letter box
+maillot
+maillot, tank suit
+manhole cover
+maraca
+marimba, xylophone
+mask
+matchstick
+maypole
+maze, labyrinth
+measuring cup
+medicine chest, medicine cabinet
+megalith, megalithic structure
+microphone, mike
+microwave, microwave oven
+military uniform
+milk can
+minibus
+miniskirt, mini
+minivan
+missile
+mitten
+mixing bowl
+mobile home, manufactured home
+Model T
+modem
+monastery
+monitor
+moped
+mortar
+mortarboard
+mosque
+mosquito net
+motor scooter, scooter
+mountain bike, all-terrain bike, off-roader
+mountain tent
+mouse, computer mouse
+mousetrap
+moving van
+muzzle
+nail
+neck brace
+necklace
+nipple
+notebook, notebook computer
+obelisk
+oboe, hautboy, hautbois
+ocarina, sweet potato
+odometer, hodometer, mileometer, milometer
+oil filter
+organ, pipe organ
+oscilloscope, scope, cathode-ray oscilloscope, CRO
+overskirt
+oxcart
+oxygen mask
+packet
+paddle, boat paddle
+paddlewheel, paddle wheel
+padlock
+paintbrush
+pajama, pyjama, pj's, jammies
+palace
+panpipe, pandean pipe, syrinx
+paper towel
+parachute, chute
+parallel bars, bars
+park bench
+parking meter
+passenger car, coach, carriage
+patio, terrace
+pay-phone, pay-station
+pedestal, plinth, footstall
+pencil box, pencil case
+pencil sharpener
+perfume, essence
+Petri dish
+photocopier
+pick, plectrum, plectron
+pickelhaube
+picket fence, paling
+pickup, pickup truck
+pier
+piggy bank, penny bank
+pill bottle
+pillow
+ping-pong ball
+pinwheel
+pirate, pirate ship
+pitcher, ewer
+plane, carpenter's plane, woodworking plane
+planetarium
+plastic bag
+plate rack
+plow, plough
+plunger, plumber's helper
+Polaroid camera, Polaroid Land camera
+pole
+police van, police wagon, paddy wagon, patrol wagon, wagon, black Maria
+poncho
+pool table, billiard table, snooker table
+pop bottle, soda bottle
+pot, flowerpot
+potter's wheel
+power drill
+prayer rug, prayer mat
+printer
+prison, prison house
+projectile, missile
+projector
+puck, hockey puck
+punching bag, punch bag, punching ball, punchball
+purse
+quill, quill pen
+quilt, comforter, comfort, puff
+racer, race car, racing car
+racket, racquet
+radiator
+radio, wireless
+radio telescope, radio reflector
+rain barrel
+recreational vehicle, RV, R.V.
+reel
+reflex camera
+refrigerator, icebox
+remote control, remote
+restaurant, eating house, eating place, eatery
+revolver, six-gun, six-shooter
+rifle
+rocking chair, rocker
+rotisserie
+rubber eraser, rubber, pencil eraser
+rugby ball
+rule, ruler
+running shoe
+safe
+safety pin
+saltshaker, salt shaker
+sandal
+sarong
+sax, saxophone
+scabbard
+scale, weighing machine
+school bus
+schooner
+scoreboard
+screen, CRT screen
+screw
+screwdriver
+seat belt, seatbelt
+sewing machine
+shield, buckler
+shoe shop, shoe-shop, shoe store
+shoji
+shopping basket
+shopping cart
+shovel
+shower cap
+shower curtain
+ski
+ski mask
+sleeping bag
+slide rule, slipstick
+sliding door
+slot, one-armed bandit
+snorkel
+snowmobile
+snowplow, snowplough
+soap dispenser
+soccer ball
+sock
+solar dish, solar collector, solar furnace
+sombrero
+soup bowl
+space bar
+space heater
+space shuttle
+spatula
+speedboat
+spider web, spider's web
+spindle
+sports car, sport car
+spotlight, spot
+stage
+steam locomotive
+steel arch bridge
+steel drum
+stethoscope
+stole
+stone wall
+stopwatch, stop watch
+stove
+strainer
+streetcar, tram, tramcar, trolley, trolley car
+stretcher
+studio couch, day bed
+stupa, tope
+submarine, pigboat, sub, U-boat
+suit, suit of clothes
+sundial
+sunglass
+sunglasses, dark glasses, shades
+sunscreen, sunblock, sun blocker
+suspension bridge
+swab, swob, mop
+sweatshirt
+swimming trunks, bathing trunks
+swing
+switch, electric switch, electrical switch
+syringe
+table lamp
+tank, army tank, armored combat vehicle, armoured combat vehicle
+tape player
+teapot
+teddy, teddy bear
+television, television system
+tennis ball
+thatch, thatched roof
+theater curtain, theatre curtain
+thimble
+thresher, thrasher, threshing machine
+throne
+tile roof
+toaster
+tobacco shop, tobacconist shop, tobacconist
+toilet seat
+torch
+totem pole
+tow truck, tow car, wrecker
+toyshop
+tractor
+trailer truck, tractor trailer, trucking rig, rig, articulated lorry, semi
+tray
+trench coat
+tricycle, trike, velocipede
+trimaran
+tripod
+triumphal arch
+trolleybus, trolley coach, trackless trolley
+trombone
+tub, vat
+turnstile
+typewriter keyboard
+umbrella
+unicycle, monocycle
+upright, upright piano
+vacuum, vacuum cleaner
+vase
+vault
+velvet
+vending machine
+vestment
+viaduct
+violin, fiddle
+volleyball
+waffle iron
+wall clock
+wallet, billfold, notecase, pocketbook
+wardrobe, closet, press
+warplane, military plane
+washbasin, handbasin, washbowl, lavabo, wash-hand basin
+washer, automatic washer, washing machine
+water bottle
+water jug
+water tower
+whiskey jug
+whistle
+wig
+window screen
+window shade
+Windsor tie
+wine bottle
+wing
+wok
+wooden spoon
+wool, woolen, woollen
+worm fence, snake fence, snake-rail fence, Virginia fence
+wreck
+yawl
+yurt
+web site, website, internet site, site
+comic book
+crossword puzzle, crossword
+street sign
+traffic light, traffic signal, stoplight
+book jacket, dust cover, dust jacket, dust wrapper
+menu
+plate
+guacamole
+consomme
+hot pot, hotpot
+trifle
+ice cream, icecream
+ice lolly, lolly, lollipop, popsicle
+French loaf
+bagel, beigel
+pretzel
+cheeseburger
+hotdog, hot dog, red hot
+mashed potato
+head cabbage
+broccoli
+cauliflower
+zucchini, courgette
+spaghetti squash
+acorn squash
+butternut squash
+cucumber, cuke
+artichoke, globe artichoke
+bell pepper
+cardoon
+mushroom
+Granny Smith
+strawberry
+orange
+lemon
+fig
+pineapple, ananas
+banana
+jackfruit, jak, jack
+custard apple
+pomegranate
+hay
+carbonara
+chocolate sauce, chocolate syrup
+dough
+meat loaf, meatloaf
+pizza, pizza pie
+potpie
+burrito
+red wine
+espresso
+cup
+eggnog
+alp
+bubble
+cliff, drop, drop-off
+coral reef
+geyser
+lakeside, lakeshore
+promontory, headland, head, foreland
+sandbar, sand bar
+seashore, coast, seacoast, sea-coast
+valley, vale
+volcano
+ballplayer, baseball player
+groom, bridegroom
+scuba diver
+rapeseed
+daisy
+yellow lady's slipper, yellow lady-slipper, Cypripedium calceolus, Cypripedium parviflorum
+corn
+acorn
+hip, rose hip, rosehip
+buckeye, horse chestnut, conker
+coral fungus
+agaric
+gyromitra
+stinkhorn, carrion fungus
+earthstar
+hen-of-the-woods, hen of the woods, Polyporus frondosus, Grifola frondosa
+bolete
+ear, spike, capitulum
+toilet tissue, toilet paper, bathroom tissue

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -50,6 +50,6 @@ mytestlib = library('mytestlib',
   dependencies : [libvaccel_private],
   install : true)
 
-foreach d : ['models', 'images', 'input']
+foreach d : ['models', 'images', 'input', 'labels']
   install_subdir(d, install_dir : 'share/vaccel')
 endforeach

--- a/examples/torch_inference.cpp
+++ b/examples/torch_inference.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
+#include <fstream>
 #include <iostream>
 #include <random>
 #include <session.h>
@@ -20,9 +21,76 @@
 
 #include <vaccel.h>
 
-auto random_input_generator(int min_value = 1, int max_value = 100,
-			    size_t vector_size = 150528,
-			    bool is_print = true) -> std::vector<float>
+auto load_labels(const std::string &file_name,
+		 std::vector<std::string> &labels) -> bool
+{
+	std::ifstream ifs(file_name);
+	if (!ifs)
+		return false;
+
+	std::string line;
+	while (std::getline(ifs, line))
+		labels.push_back(line);
+
+	return true;
+}
+
+auto preprocess(const unsigned char *image_data, int width, int height,
+		int channels, float *output_buffer) -> int
+{
+	if (channels != 3) {
+		std::cerr << "Error: Only 3-channel RGB images are supported\n";
+		return VACCEL_EINVAL;
+	}
+
+	/* Target dimensions for resizing */
+	const int target_width = 224;
+	const int target_height = 224;
+
+	/* Mean and standard deviation for normalization */
+	const float mean[] = { 0.485F, 0.456F, 0.406F };
+	const float std[] = { 0.229F, 0.224F, 0.225F };
+
+	/* Allocate intermediate buffer for resized image */
+	std::vector<unsigned char> resized_image(
+		(size_t)(target_width * target_height * 3));
+
+	/* Resize manually (nearest neighbor interpolation) */
+	for (int y = 0; y < target_height; ++y) {
+		for (int x = 0; x < target_width; ++x) {
+			int src_x = x * width / target_width;
+			int src_y = y * height / target_height;
+			for (int c = 0; c < 3; ++c) {
+				resized_image[(y * target_width + x) * 3 + c] =
+					image_data[(src_y * width + src_x) * 3 +
+						   c];
+			}
+		}
+	}
+
+	/* Normalize and reorder channels to [C, H, W] */
+	for (int c = 0; c < 3; ++c) {
+		for (int y = 0; y < target_height; ++y) {
+			for (int x = 0; x < target_width; ++x) {
+				unsigned char pixel_value =
+					resized_image[(y * target_width + x) * 3 +
+						      c];
+				float normalized_value =
+					((float)pixel_value / 255.0F -
+					 mean[c]) /
+					std[c];
+				output_buffer[c * target_width * target_height +
+					      y * target_width + x] =
+					normalized_value;
+			}
+		}
+	}
+	return VACCEL_OK;
+}
+
+auto generate_random_input(int min_value = 1, int max_value = 100,
+			   size_t vector_size = 150528,
+			   bool is_print = true) -> std::vector<float>
 {
 	// Create a random number generator engine
 	std::random_device rd;
@@ -48,29 +116,48 @@ auto random_input_generator(int min_value = 1, int max_value = 100,
 	return res_data;
 }
 
+const int target_width = 224;
+const int target_height = 224;
+const int target_channels = 3;
+
+#ifdef USE_STB_IMAGE
+const int nr_req_args = 4;
+const std::string usage_args = "image-path model-path labels-path";
+#else
+const int nr_req_args = 3;
+const std::string usage_args = "image-path model-path";
+#endif
+
 auto main(int argc, char **argv) -> int
 {
+	if (argc < nr_req_args) {
+		std::cerr << "Usage: " << argv[0] << " " << usage_args << '\n';
+		return VACCEL_EINVAL;
+	}
+
 	struct vaccel_session sess;
 	struct vaccel_resource model;
 	struct vaccel_torch_buffer run_options;
 	int ret;
-	char *model_path = argv[2];
-	int64_t dims[] = { 1, 224, 224, 3 };
+	int64_t dims[] = { 1, 3, 224, 224 };
 	struct vaccel_torch_tensor *in;
 	struct vaccel_torch_tensor *out;
 	std::vector<float> res_data;
+#ifdef USE_STB_IMAGE
+	float *preprocessed_data = nullptr;
+	float max;
+	unsigned int max_idx;
+	float *response_ptr;
+	std::vector<std::string> labels;
+#endif
 
-	if (argc != 3) {
-		fprintf(stderr, "Usage: %s image filename, model path\n",
-			argv[0]);
-		exit(1);
-	}
-
-	ret = vaccel_resource_init(&model, model_path, VACCEL_RESOURCE_MODEL);
+	ret = vaccel_resource_init(&model, argv[2], VACCEL_RESOURCE_MODEL);
 	if (ret != 0) {
 		fprintf(stderr, "Could not create model resource\n");
 		return ret;
 	}
+
+	printf("Initialized vAccel resource %" PRId64 "\n", model.id);
 
 	ret = vaccel_session_init(&sess, 0);
 	if (ret != VACCEL_OK) {
@@ -80,15 +167,24 @@ auto main(int argc, char **argv) -> int
 
 	printf("Initialized vAccel session %" PRId64 "\n", sess.id);
 
-	/* Take vaccel_session and vaccel_resource as inputs, 
-	 * register a resource with a session */
 	ret = vaccel_resource_register(&model, &sess);
 	if (ret != VACCEL_OK) {
 		fprintf(stderr, "Could not register model with session\n");
 		goto close_session;
 	}
 
+	in = vaccel_torch_tensor_new(4, dims, VACCEL_TORCH_FLOAT);
+	if (in == nullptr) {
+		fprintf(stderr, "Could not allocate memory\n");
+		goto unregister_session;
+	}
+
 #ifdef USE_STB_IMAGE
+	if (!load_labels(argv[3], labels)) {
+		fprintf(stderr, "Could not load labels from %s", argv[3]);
+		return VACCEL_ENOENT;
+	}
+
 	int width;
 	int height;
 	int channels;
@@ -97,31 +193,44 @@ auto main(int argc, char **argv) -> int
 	img_data = stbi_load(argv[1], &width, &height, &channels, 0);
 	if (img_data == nullptr) {
 		std::cerr << "Failed to load image\n";
-		return -1;
-	}
-
-	res_data.reserve((size_t)width * (size_t)height * (size_t)channels);
-
-	for (int i = 0; i < width * height * channels; ++i) {
-		res_data.push_back((float)img_data[i] /
-				   255.0F); // Normalize pixel value
-	}
-	stbi_image_free(img_data);
-#else
-	res_data = random_input_generator();
-	res_data.resize((size_t)(224 * 224 * 3));
-#endif
-
-	in = vaccel_torch_tensor_new(4, dims, VACCEL_TORCH_FLOAT);
-	if (in == nullptr) {
-		fprintf(stderr, "Could not allocate memory\n");
+		ret = VACCEL_EINVAL;
 		goto unregister_session;
 	}
 
+	preprocessed_data = new float[(size_t)(target_width * target_height *
+					       target_channels)];
+	if (preprocessed_data == nullptr) {
+		fprintf(stderr, "Could not allocate memory to process data");
+		stbi_image_free(img_data);
+		ret = VACCEL_ENOMEM;
+		goto unregister_session;
+	}
+
+	memset(preprocessed_data, 0,
+	       (size_t)(target_width * target_height * target_channels) *
+		       sizeof(float));
+
+	ret = preprocess(img_data, width, height, channels, preprocessed_data);
+	if (ret != 0) {
+		fprintf(stderr, "Could not preprocess image data");
+		stbi_image_free(img_data);
+		goto unregister_session;
+	}
+
+	stbi_image_free(img_data);
+
+	in->data = (void *)preprocessed_data;
+	in->size = (size_t)(target_width * target_height * target_channels) *
+		   sizeof(float);
+#else
+	res_data = generate_random_input();
+	res_data.resize((size_t)(224 * 224 * 3));
+
 	in->data = res_data.data();
 	in->size = res_data.size() * sizeof(float);
+#endif
 
-	run_options.data = strdup("resnet");
+	run_options.data = strdup("mobilenet");
 	run_options.size = strlen(run_options.data) + 1;
 
 	/* Output tensor */
@@ -144,15 +253,22 @@ auto main(int argc, char **argv) -> int
 	printf("Result Tensor :\n");
 	printf("Output tensor => type:%u nr_dims:%u\n", out->data_type,
 	       out->nr_dims);
-	printf("data: %f\n", *(float *)out->data);
 	printf("size: %zu\n", out->size);
-	/*
-	   const char* classes[10] = { "plane", "car", "bird", 
-	   "cat", "deer", "dog", 
-	   "frog", "horse", "ship", "truck" };
 
-	   printf("Pred: %s\n", classes[int(offsets)])
-	   */
+#ifdef USE_STB_IMAGE
+	response_ptr = reinterpret_cast<float *>(out->data);
+	max = response_ptr[0];
+	max_idx = 0;
+
+	for (auto i = 1; i != 1000; ++i) {
+		if (response_ptr[i] > max) {
+			max = response_ptr[i];
+			max_idx = i;
+		}
+	}
+
+	std::cout << "Prediction: " << labels[max_idx] << '\n';
+#endif
 
 	if (vaccel_torch_tensor_destroy(out) != VACCEL_OK)
 		fprintf(stderr, "Could not destroy out tensor\n");
@@ -161,6 +277,9 @@ free_tensor:
 	if (vaccel_torch_tensor_destroy(in) != VACCEL_OK)
 		fprintf(stderr, "Could not destroy in tensor\n");
 unregister_session:
+#ifdef USE_STB_IMAGE
+	delete[] preprocessed_data;
+#endif
 	if (vaccel_resource_unregister(&model, &sess) != VACCEL_OK)
 		fprintf(stderr, "Could not unregister model with session\n");
 close_session:

--- a/scripts/config/valgrind.supp
+++ b/scripts/config/valgrind.supp
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+{
+   libssh constructor/destructor errors (for armv7l)
+   Memcheck:Addr4
+   obj:/usr/lib/arm-linux-gnueabihf/libssh.so*
+}

--- a/scripts/config/variables.env
+++ b/scripts/config/variables.env
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+SCRIPTS_CONFIG_DIR=${SCRIPTS_DIR:-'.'}/config
+SCRIPTS_VALGRIND_CMD="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --errors-for-leak-kinds=all --max-stackframe=3150000 --error-exitcode=1 --suppressions=${SCRIPTS_CONFIG_DIR}/valgrind.supp"

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -79,7 +79,8 @@ eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/tflite_inference" \
 	"${SHARE_DIR}/models/tf/lstm2.tflite"
 eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/torch_inference" \
 	"${SHARE_DIR}/images/example.jpg" \
-	"${SHARE_DIR}/models/torch/cnn_trace.pt"
+	https://s3.nbfc.io/torch/mobilenet.pt \
+	"${SHARE_DIR}/labels/imagenet.txt"
 eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/mbench" 1 \
 	"${SHARE_DIR}/images/example.jpg"
 eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/exec" \

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -3,8 +3,13 @@
 
 set -e
 
+SCRIPTS_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
+# shellcheck source=scripts/config/variables.env
+. "${SCRIPTS_DIR}/config/variables.env"
+
 PREFIX=${1:-"/usr/local"}
 VALGRIND=$2
+[ "${VALGRIND}" = "true" ] && WRAPPER_CMD=${SCRIPTS_VALGRIND_CMD:-'valgrind'}
 if [ -n "${MESON_BUILD_ROOT}" ]; then
 	LIB_DIR=${MESON_BUILD_ROOT}/src
 	EXAMPLES_DIR=${MESON_BUILD_ROOT}/examples
@@ -22,13 +27,6 @@ else
 	NOOP_DIR=${LIB_DIR}
 	MBENCH_DIR=${LIB_DIR}
 	EXEC_DIR=${LIB_DIR}
-fi
-
-if [ "${VALGRIND}" = "true" ]; then
-	WRAPPER_CMD="valgrind"
-	WRAPPER_CMD="${WRAPPER_CMD} --leak-check=full --show-leak-kinds=all"
-	WRAPPER_CMD="${WRAPPER_CMD} --track-origins=yes --errors-for-leak-kinds=all"
-	WRAPPER_CMD="${WRAPPER_CMD} --max-stackframe=3145916 --error-exitcode=1"
 fi
 
 [ -z "${TERM}" ] && export TERM="linux"
@@ -79,7 +77,7 @@ eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/tflite_inference" \
 	"${SHARE_DIR}/models/tf/lstm2.tflite"
 eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/torch_inference" \
 	"${SHARE_DIR}/images/example.jpg" \
-	https://s3.nbfc.io/torch/mobilenet.pt \
+	'https://s3.nbfc.io/torch/mobilenet.pt' \
 	"${SHARE_DIR}/labels/imagenet.txt"
 eval "${WRAPPER_CMD}" "${EXAMPLES_DIR}/mbench" 1 \
 	"${SHARE_DIR}/images/example.jpg"


### PR DESCRIPTION
Update torch inference example:
 - Use a different model (`mobilenet`)
 - Let the program read labels from file to print the result (only for stb mode)
 - Use `mobilenet` type in `run_options` to use the new forward function of torch plugin
 - preprocess image to be passed in the mobilenet
 - Uploaded the model in `s3.nbfc.io/torch/mobilenet.pt`
 - Uploaded the imageNet labels in `s3.nbfc.io/imagenet/label.txt`