### PR TITLE
feat(examples): Introduce additional options for examples

### DIFF
--- a/examples/classify.c
+++ b/examples/classify.c
@@ -14,12 +14,30 @@ int main(int argc, char *argv[])
 	size_t image_size;
 	char out_text[512];
 	char out_imagename[512];
+#if VACCEL_EXAMPLES_MODEL_RESOURCE
+	struct vaccel_resource model;
+#endif
 	struct vaccel_session sess;
 
+#if VACCEL_EXAMPLES_MODEL_RESOURCE
+	if (argc != 4) {
+		fprintf(stderr, "Usage: %s filename #iterations model\n",
+			argv[0]);
+		return 0;
+	}
+#else
 	if (argc != 3) {
 		fprintf(stderr, "Usage: %s filename #iterations\n", argv[0]);
 		return 0;
 	}
+#endif
+#if VACCEL_EXAMPLES_MODEL_RESOURCE
+	ret = vaccel_resource_init(&model, argv[3], VACCEL_RESOURCE_MODEL);
+	if (ret != 0) {
+		fprintf(stderr, "Could not create model resource\n");
+		return ret;
+	}
+#endif
 
 	ret = vaccel_session_init(&sess, 0);
 	if (ret != VACCEL_OK) {
@@ -29,30 +47,55 @@ int main(int argc, char *argv[])
 
 	printf("Initialized session with id: %" PRId64 "\n", sess.id);
 
+#if VACCEL_EXAMPLES_MODEL_RESOURCE
+	ret = vaccel_resource_register(&model, &sess);
+	if (ret) {
+		fprintf(stderr, "Could register shared object to session\n");
+		exit(1);
+	}
+#endif
 	ret = fs_file_read(argv[1], (void **)&image, &image_size);
 	if (ret)
 		goto close_session;
 
 	for (int i = 0; i < atoi(argv[2]); ++i) {
+#if VACCEL_EXAMPLES_PROFILE
+		struct vaccel_prof_region inference_nested =
+			VACCEL_PROF_REGION_INIT("inference_nested");
+		vaccel_prof_region_start(&inference_nested);
+#endif
 		ret = vaccel_image_classification(
 			&sess, image, (unsigned char *)out_text,
 			(unsigned char *)out_imagename, image_size,
 			sizeof(out_text), sizeof(out_imagename));
+#if VACCEL_EXAMPLES_PROFILE
+		vaccel_prof_region_stop(&inference_nested);
+#endif
 		if (ret) {
 			fprintf(stderr, "Could not run op: %d\n", ret);
 			goto close_session;
 		}
 
+#if VACCEL_EXAMPLES_PROFILE
+		vaccel_prof_region_print(&inference_nested);
+#endif
 		if (i == 0)
 			printf("classification tags: %s\n", out_text);
 	}
 
 close_session:
+#if VACCEL_EXAMPLES_MODEL_RESOURCE
+	if (vaccel_resource_unregister(&model, &sess) != VACCEL_OK)
+		fprintf(stderr, "Could not unregister model from session\n");
+#endif
 	free(image);
 	if (vaccel_session_release(&sess) != VACCEL_OK) {
 		fprintf(stderr, "Could not clear session\n");
 		return 1;
 	}
+#if VACCEL_EXAMPLES_MODEL_RESOURCE
+	vaccel_resource_release(&model);
+#endif
 
 	return ret;
 }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -32,6 +32,13 @@ examples_sources = files([
   'local_and_virtio.c',
 ])
 
+
+if opt_examples_model.enabled()
+  vaccel_c_args += '-DVACCEL_EXAMPLES_MODEL_RESOURCE=1'
+endif
+if opt_examples_profile.enabled()
+  vaccel_c_args += '-DVACCEL_EXAMPLES_PROFILE=1'
+endif
 examples = []
 foreach e : examples_sources
   examples += executable(fs.stem(e),

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,8 @@ libvaccel_version = meson.project_version().split('-')[0]
 
 opt_tests = get_option('tests')
 opt_examples = get_option('examples').enable_if(opt_tests.enabled())
+opt_examples_model = get_option('examples-model')
+opt_examples_profile = get_option('examples-profile')
 
 slog_subproj = subproject('slog')
 libslog_dep = dependency('slog')
@@ -54,6 +56,8 @@ summary({
   'Build the no-op debugging plugin': opt_plugin_noop.enabled(),
   'Build the mbench plugin': opt_plugin_mbench.enabled(),
   'Build the examples': opt_examples.enabled(),
+  'Allow model specification in the examples': opt_examples_model.enabled(),
+  'Enable profiling code in the examples': opt_examples_profile.enabled(),
   'Enable testing': opt_tests.enabled(),
   },
   section : 'Configuration',
@@ -68,6 +72,8 @@ meson.add_dist_script(
   '-a', 'plugin-noop=' + (opt_plugin_noop.enabled() ? 'enabled' : 'disabled'),
   '-a', 'plugin-mbench=' + (opt_plugin_mbench.enabled() ? 'enabled' : 'disabled'),
   '-a', 'examples=' + (opt_examples.enabled() ? 'enabled' : 'disabled'),
+  '-a', 'examples-model=' + (opt_examples_model.enabled() ? 'enabled' : 'disabled'),
+  '-a', 'examples-profile=' + (opt_examples_profile.enabled() ? 'enabled' : 'disabled'),
   '-a', 'tests=' + (opt_tests.enabled() ? 'enabled' : 'disabled'))
 
 if opt_examples.enabled() and opt_plugin_noop.enabled() and opt_plugin_exec.enabled()

--- a/meson.options
+++ b/meson.options
@@ -23,6 +23,16 @@ option('examples',
   value : 'auto',
   description : 'Build the examples')
 
+option('examples-model',
+  type : 'feature',
+  value : 'disabled',
+  description : 'Allow to specify the model in examples')
+
+option('examples-profile',
+  type : 'feature',
+  value : 'disabled',
+  description : 'Enable profiling code in examples')
+
 option('tests',
   type : 'feature',
   value : 'auto',


### PR DESCRIPTION
Allow examples (for now `classify.c`) to specify the model against which inference is going to be done in the plugin. For now, we assume that the model is loaded as a resource, with type `VACCEL_RESOURCE_MODEL` and the plugin pops the first available resource with this type to use it.

This is useful in our TVM example.

Add this as an optional argument in meson:
`meson setup -Dexamples-model=enabled --reconfigure build`

Additionally, add an extra parameter for profiling:

`meson setup -Dexamples-profile=enabled --reconfigure build`