### PR TITLE
bug(tests): Ignore `snprintf` warning

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -21,7 +21,8 @@ subdir('ops')
 subdir('utils')
 
 tests_cpp_args = vaccel_cpp_args + [
-  '-DCATCH_CONFIG_FAST_COMPILE'
+  '-DCATCH_CONFIG_FAST_COMPILE',
+  '-Wno-format-truncation'
 ]
 
 tests_args = [


### PR DESCRIPTION
Apparently it seems that people are much more sanguine about disabling this warning globally using -Wno-format-truncation, rather than trying to coax gcc into ignoring a specific instance with preprocessor definitions (context: https://stackoverflow.com/a/64047565).