### PR TITLE
ci: Add `vaccel-bot` to contributors

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -5,6 +5,9 @@ users:
   dependabotbot:
     name: dependabot[bot]
     email: support@github.com
+  vaccel-botbot:
+    name: vaccel-bot[bot]
+    email: 175908213+vaccel-bot[bot]@users.noreply.github.com
   ananos:
     name: Anastassios Nanos
     email: ananos@nubificus.co.uk


### PR DESCRIPTION
Add `vaccel-bot` to `contributors.yaml`