### PR TITLE
ci(tests): Fix valgrind execution on 32-bit arm

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -27,8 +27,10 @@ runs:
       working-directory: ${{ inputs.source-path }}
       if: ${{ inputs.valgrind == 'true' }}
       run: |
+          # Needed for armv7l OpenSSL "reachable" mem & SIGKILL
+          export OPENSSL_armcap=0
           meson test \
-            --wrap="${{ env.SCRIPTS_VALGRIND_CMD }}" \
+            --wrap="${{ env.SCRIPTS_VALGRIND_CMD }} --sigill-diagnostics=no" \
             -t 7 \
             --print-errorlogs \
             -C "${{ inputs.build-path }}"

--- a/scripts/config/valgrind.supp
+++ b/scripts/config/valgrind.supp
@@ -5,3 +5,33 @@
    Memcheck:Addr4
    obj:/usr/lib/arm-linux-gnueabihf/libssh.so*
 }
+
+{
+   OpenSSL reachable blocks (libcrypto)
+   Memcheck:Leak
+   obj:/usr/lib/arm-linux-gnueabihf/libcrypto.so*
+}
+
+{
+   OpenSSL reachable blocks (libssl)
+   Memcheck:Leak
+   obj:/usr/lib/arm-linux-gnueabihf/libssl.so*
+}
+
+{
+   libcurl reachable blocks
+   Memcheck:Leak
+   obj:/usr/lib/arm-linux-gnueabihf/libcurl.so*
+}
+
+{
+   libtasn1 reachable blocks
+   Memcheck:Leak
+   obj:/usr/lib/arm-linux-gnueabihf/libtasn1.so*
+}
+
+{
+   libstdc++ reachable blocks
+   Memcheck:Leak
+   obj:/usr/lib/arm-linux-gnueabihf/libstdc++.so*
+}

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -7,9 +7,17 @@ SCRIPTS_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
 # shellcheck source=scripts/config/variables.env
 . "${SCRIPTS_DIR}/config/variables.env"
 
+BIN_FILE="/bin/ls"
+ARCH_INFO=$(file "$BIN_FILE")
+if echo "$ARCH_INFO" | grep -q "32-bit"; then
+	VALGRIND_SIGILL_OPT="--sigill-diagnostics=no"
+	export OPENSSL_armcap=0
+fi
+
 PREFIX=${1:-"/usr/local"}
 VALGRIND=$2
 [ "${VALGRIND}" = "true" ] && WRAPPER_CMD=${SCRIPTS_VALGRIND_CMD:-'valgrind'}
+[ "${VALGRIND}" = "true" ] && WRAPPER_CMD="$WRAPPER_CMD $VALGRIND_SIGILL_OPT"
 if [ -n "${MESON_BUILD_ROOT}" ]; then
 	LIB_DIR=${MESON_BUILD_ROOT}/src
 	EXAMPLES_DIR=${MESON_BUILD_ROOT}/examples


### PR DESCRIPTION
According to https://bugs.kde.org/show_bug.cgi?id=344802, using `--sigill-diagnostics=no` allows 32-bit tests to run correctly. This is related to `libcrypto.so`.

Additionally, it seems that OpenSSL and `valgrind` do not play well together. We disable any optimizations when running on arm32, and suppress any reachable memory references from `valgrind`, as they seem to be false-positives.