### PR TITLE
ci(coverage): Build with debug type to use prebuilt artifacts

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: base-dind-2204-amd64
     strategy:
       matrix:
-        build-type: [plain]
+        build-type: [debug]
       fail-fast: false
     env:
       DOWNLOAD_PATH: >-


### PR DESCRIPTION
Use debug build-type in the `coverage-report` workflow. Artifacts are only prebuilt for debug/release, so non-core repos could not reuse them via the download-from-s3 step with the plain build-type.