### PR TITLE
feat(examples): Resolve class IDs in classify/detect examples

### DIFF
--- a/examples/classify.c
+++ b/examples/classify.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "common/inference_helpers.h"
 #include "utils/fs.h"
 #include "vaccel.h"
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,12 +20,14 @@ int main(int argc, char *argv[])
 	unsigned char out_imagename[STR_SIZE_MAX] = { '\0' };
 	struct vaccel_session sess;
 	struct vaccel_resource model = { .id = 0 };
+	char **labels = NULL;
+	size_t nr_labels = 0;
 	struct vaccel_prof_region classify_stats =
 		VACCEL_PROF_REGION_INIT("classify");
 
-	if (argc < 2 || argc > 4) {
+	if (argc < 2 || argc > 5) {
 		fprintf(stderr,
-			"Usage: %s <image_file> [iterations] [model_path]\n",
+			"Usage: %s <image_file> [iterations] [model_path] [labels_path]\n",
 			argv[0]);
 		return VACCEL_EINVAL;
 	}
@@ -36,7 +40,7 @@ int main(int argc, char *argv[])
 
 	printf("Initialized session with id: %" PRId64 "\n", sess.id);
 
-	if (argc == 4) {
+	if (argc >= 4) {
 		ret = vaccel_resource_init(&model, argv[3],
 					   VACCEL_RESOURCE_MODEL);
 		if (ret) {
@@ -52,9 +56,18 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (argc == 5) {
+		ret = inference_load_labels(argv[4], &labels, &nr_labels);
+		if (ret) {
+			fprintf(stderr, "Could not load labels from %s\n",
+				argv[4]);
+			goto unregister_resource;
+		}
+	}
+
 	ret = fs_file_read(argv[1], (void **)&image, &image_size);
 	if (ret)
-		goto unregister_resource;
+		goto free_labels;
 
 	const int iter = (argc > 2) ? atoi(argv[2]) : 1;
 	for (int i = 0; i < iter; i++) {
@@ -69,13 +82,21 @@ int main(int argc, char *argv[])
 
 		if (ret) {
 			fprintf(stderr, "Could not run op: %d\n", ret);
-			goto unregister_resource;
+			goto free_labels;
 		}
 
-		printf("classification tags: %s\n", out_text);
+		const char *tag = inference_resolve_label((char *)out_text,
+							  labels, nr_labels);
+		printf("classification tags: %s\n", tag);
 		printf("classification imagename: %s\n", out_imagename);
 	}
 
+free_labels:
+	if (labels) {
+		for (size_t i = 0; i < nr_labels; i++)
+			free(labels[i]);
+		free(labels);
+	}
 unregister_resource:
 	if (model.id > 0 && vaccel_resource_unregister(&model, &sess))
 		fprintf(stderr, "Could not unregister model from session\n");

--- a/examples/classify_generic.c
+++ b/examples/classify_generic.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "common/inference_helpers.h"
 #include "utils/fs.h"
 #include "vaccel.h"
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,12 +20,14 @@ int main(int argc, char *argv[])
 	unsigned char out_imagename[STR_SIZE_MAX] = { '\0' };
 	struct vaccel_session sess;
 	struct vaccel_resource model = { .id = 0 };
+	char **labels = NULL;
+	size_t nr_labels = 0;
 	struct vaccel_prof_region classify_stats =
 		VACCEL_PROF_REGION_INIT("classify");
 
-	if (argc < 2 || argc > 4) {
+	if (argc < 2 || argc > 5) {
 		fprintf(stderr,
-			"Usage: %s <image_file> [iterations] [model_path]\n",
+			"Usage: %s <image_file> [iterations] [model_path] [labels_path]\n",
 			argv[0]);
 		return VACCEL_EINVAL;
 	}
@@ -36,7 +40,7 @@ int main(int argc, char *argv[])
 
 	printf("Initialized session with id: %" PRId64 "\n", sess.id);
 
-	if (argc == 4) {
+	if (argc >= 4) {
 		ret = vaccel_resource_init(&model, argv[3],
 					   VACCEL_RESOURCE_MODEL);
 		if (ret) {
@@ -52,15 +56,24 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (argc == 5) {
+		ret = inference_load_labels(argv[4], &labels, &nr_labels);
+		if (ret) {
+			fprintf(stderr, "Could not load labels from %s\n",
+				argv[4]);
+			goto unregister_resource;
+		}
+	}
+
 	ret = fs_file_read(argv[1], (void **)&image, &image_size);
 	if (ret)
-		goto unregister_resource;
+		goto free_labels;
 
 	struct vaccel_arg_array read_args;
 	ret = vaccel_arg_array_init(&read_args, 2);
 	if (ret) {
 		fprintf(stderr, "Could not initialize read args array\n");
-		goto unregister_resource;
+		goto free_labels;
 	}
 
 	struct vaccel_arg_array write_args;
@@ -111,7 +124,9 @@ int main(int argc, char *argv[])
 			goto unregister_resource;
 		}
 
-		printf("classification tags: %s\n", out_text);
+		const char *tag = inference_resolve_label((char *)out_text,
+							  labels, nr_labels);
+		printf("classification tags: %s\n", tag);
 		printf("classification imagename: %s\n", out_imagename);
 	}
 
@@ -121,6 +136,12 @@ release_write_args_array:
 release_read_args_array:
 	if (vaccel_arg_array_release(&read_args))
 		fprintf(stderr, "Could not release read args array\n");
+free_labels:
+	if (labels) {
+		for (size_t i = 0; i < nr_labels; i++)
+			free(labels[i]);
+		free(labels);
+	}
 unregister_resource:
 	if (model.id > 0 && vaccel_resource_unregister(&model, &sess))
 		fprintf(stderr, "Could not unregister model from session\n");

--- a/examples/common/inference_helpers.c
+++ b/examples/common/inference_helpers.c
@@ -3,31 +3,62 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include "inference_helpers.h"
+#include "utils/net.h"
+#include "utils/path.h"
 #include "vaccel.h"
 #include <errno.h>
+#include <limits.h>
+#include <linux/limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #ifdef USE_STB_IMAGE
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 #endif
 
-int inference_load_labels(const char *filename, char ***labels,
-			  size_t *nr_labels)
+int inference_load_labels(const char *path, char ***labels, size_t *nr_labels)
 {
-	if (!filename || !labels || !nr_labels)
+	if (!path || !labels || !nr_labels)
 		return VACCEL_EINVAL;
 
 	int ret = VACCEL_OK;
+	char dl_path[PATH_MAX];
+	const char *load_path = path;
+	bool is_temp = false;
 
-	FILE *file = fopen(filename, "r");
+	/* If `path` is a URL, download in a temporary vaccel rundir path */
+	if (net_path_is_url(path)) {
+		char filename[NAME_MAX];
+		ret = path_file_name(path, filename, NAME_MAX, NULL);
+		if (ret)
+			return ret;
+
+		ret = path_init_from_parts(dl_path, sizeof(dl_path),
+					   vaccel_rundir(), filename, NULL);
+		if (ret)
+			return ret;
+
+		ret = net_file_download(path, dl_path);
+		if (ret) {
+			unlink(dl_path);
+			return ret;
+		}
+
+		load_path = dl_path;
+		is_temp = true;
+	}
+
+	FILE *file = fopen(load_path, "r");
 	if (!file) {
-		fprintf(stderr, "Failed to open %s: %s\n", filename,
+		fprintf(stderr, "Failed to open %s: %s\n", load_path,
 			strerror(errno));
-		return VACCEL_EINVAL;
+		ret = VACCEL_EINVAL;
+		goto out_unlink;
 	}
 
 	size_t num_lines = 0;
@@ -81,7 +112,29 @@ int inference_load_labels(const char *filename, char ***labels,
 
 out_fclose:
 	fclose(file);
+out_unlink:
+	if (is_temp)
+		unlink(dl_path);
 	return ret;
+}
+
+const char *inference_resolve_label(const char *token, char **labels,
+				    size_t nr_labels)
+{
+	if (!token || !labels || nr_labels == 0)
+		return token;
+
+	/* If `token` parses as a non-negative integer in [0, nr_labels), return
+	 * `labels[id]`. Otherwise return `token` unchanged so older plugins
+	 * that already emit class names pass through. */
+	char *end;
+	errno = 0;
+	long const id = strtol(token, &end, 10);
+	if (errno != 0 || end == token || *end != '\0' || id < 0 ||
+	    (size_t)id >= nr_labels)
+		return token;
+
+	return labels[id];
 }
 
 int inference_preprocess_image(const unsigned char *image_data, int width,

--- a/examples/common/inference_helpers.h
+++ b/examples/common/inference_helpers.h
@@ -19,8 +19,9 @@ typedef enum {
 	INFERENCE_IMAGE_FORMAT_TF
 } inference_image_format_t;
 
-int inference_load_labels(const char *filename, char ***labels,
-			  size_t *nr_labels);
+int inference_load_labels(const char *path, char ***labels, size_t *nr_labels);
+const char *inference_resolve_label(const char *token, char **labels,
+				    size_t nr_labels);
 int inference_preprocess_image(const unsigned char *image_data, int width,
 			       int height, int channels,
 			       inference_image_format_t format,

--- a/examples/detect.c
+++ b/examples/detect.c
@@ -1,13 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "common/inference_helpers.h"
 #include "utils/fs.h"
 #include "vaccel.h"
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 enum { STR_SIZE_MAX = 512 };
+
+static void print_detections(const unsigned char *raw, char **labels,
+			     size_t nr_labels)
+{
+	if (!labels || nr_labels == 0) {
+		printf("detection imagename: %s\n", raw);
+		return;
+	}
+
+	char buf[STR_SIZE_MAX];
+	strncpy(buf, (const char *)raw, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+
+	printf("detections:\n");
+	char *saveptr = NULL;
+	for (char *det = strtok_r(buf, ";", &saveptr); det != NULL;
+	     det = strtok_r(NULL, ";", &saveptr)) {
+		while (*det == ' ')
+			det++;
+		char *space = strchr(det, ' ');
+		if (space == NULL) {
+			printf("  %s\n", det);
+			continue;
+		}
+		*space = '\0';
+		const char *name =
+			inference_resolve_label(det, labels, nr_labels);
+		printf("  %s %s\n", name, space + 1);
+	}
+}
 
 int main(int argc, char *argv[])
 {
@@ -17,12 +50,14 @@ int main(int argc, char *argv[])
 	unsigned char out_imagename[STR_SIZE_MAX] = { '\0' };
 	struct vaccel_session sess;
 	struct vaccel_resource model = { .id = 0 };
+	char **labels = NULL;
+	size_t nr_labels = 0;
 	struct vaccel_prof_region detect_stats =
 		VACCEL_PROF_REGION_INIT("detect");
 
-	if (argc < 2 || argc > 4) {
+	if (argc < 2 || argc > 5) {
 		fprintf(stderr,
-			"Usage: %s <image_file> [iterations] [model_path]\n",
+			"Usage: %s <image_file> [iterations] [model_path] [labels_path]\n",
 			argv[0]);
 		return VACCEL_EINVAL;
 	}
@@ -35,7 +70,7 @@ int main(int argc, char *argv[])
 
 	printf("Initialized session with id: %" PRId64 "\n", sess.id);
 
-	if (argc == 4) {
+	if (argc >= 4) {
 		ret = vaccel_resource_init(&model, argv[3],
 					   VACCEL_RESOURCE_MODEL);
 		if (ret) {
@@ -51,9 +86,18 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (argc == 5) {
+		ret = inference_load_labels(argv[4], &labels, &nr_labels);
+		if (ret) {
+			fprintf(stderr, "Could not load labels from %s\n",
+				argv[4]);
+			goto unregister_resource;
+		}
+	}
+
 	ret = fs_file_read(argv[1], (void **)&image, &image_size);
 	if (ret)
-		goto unregister_resource;
+		goto free_labels;
 
 	const int iter = (argc > 2) ? atoi(argv[2]) : 1;
 	for (int i = 0; i < iter; i++) {
@@ -66,12 +110,18 @@ int main(int argc, char *argv[])
 
 		if (ret) {
 			fprintf(stderr, "Could not run op: %d\n", ret);
-			goto unregister_resource;
+			goto free_labels;
 		}
 
-		printf("detection imagename: %s\n", out_imagename);
+		print_detections(out_imagename, labels, nr_labels);
 	}
 
+free_labels:
+	if (labels) {
+		for (size_t i = 0; i < nr_labels; i++)
+			free(labels[i]);
+		free(labels);
+	}
 unregister_resource:
 	if (model.id > 0 && vaccel_resource_unregister(&model, &sess))
 		fprintf(stderr, "Could not unregister model from session\n");

--- a/examples/detect_generic.c
+++ b/examples/detect_generic.c
@@ -1,13 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "common/inference_helpers.h"
 #include "utils/fs.h"
 #include "vaccel.h"
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 enum { STR_SIZE_MAX = 512 };
+
+static void print_detections(const unsigned char *raw, char **labels,
+			     size_t nr_labels)
+{
+	if (!labels || nr_labels == 0) {
+		printf("detection imagename: %s\n", raw);
+		return;
+	}
+
+	char buf[STR_SIZE_MAX];
+	strncpy(buf, (const char *)raw, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+
+	printf("detections:\n");
+	char *saveptr = NULL;
+	for (char *det = strtok_r(buf, ";", &saveptr); det != NULL;
+	     det = strtok_r(NULL, ";", &saveptr)) {
+		while (*det == ' ')
+			det++;
+		char *space = strchr(det, ' ');
+		if (space == NULL) {
+			printf("  %s\n", det);
+			continue;
+		}
+		*space = '\0';
+		const char *name =
+			inference_resolve_label(det, labels, nr_labels);
+		printf("  %s %s\n", name, space + 1);
+	}
+}
 
 int main(int argc, char *argv[])
 {
@@ -17,12 +50,14 @@ int main(int argc, char *argv[])
 	unsigned char out_imagename[STR_SIZE_MAX] = { '\0' };
 	struct vaccel_session sess;
 	struct vaccel_resource model = { .id = 0 };
+	char **labels = NULL;
+	size_t nr_labels = 0;
 	struct vaccel_prof_region detect_stats =
 		VACCEL_PROF_REGION_INIT("detect");
 
-	if (argc < 2 || argc > 4) {
+	if (argc < 2 || argc > 5) {
 		fprintf(stderr,
-			"Usage: %s <image_file> [iterations] [model_path]\n",
+			"Usage: %s <image_file> [iterations] [model_path] [labels_path]\n",
 			argv[0]);
 		return VACCEL_EINVAL;
 	}
@@ -35,7 +70,7 @@ int main(int argc, char *argv[])
 
 	printf("Initialized session with id: %" PRId64 "\n", sess.id);
 
-	if (argc == 4) {
+	if (argc >= 4) {
 		ret = vaccel_resource_init(&model, argv[3],
 					   VACCEL_RESOURCE_MODEL);
 		if (ret) {
@@ -51,15 +86,24 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (argc == 5) {
+		ret = inference_load_labels(argv[4], &labels, &nr_labels);
+		if (ret) {
+			fprintf(stderr, "Could not load labels from %s\n",
+				argv[4]);
+			goto unregister_resource;
+		}
+	}
+
 	ret = fs_file_read(argv[1], (void **)&image, &image_size);
 	if (ret)
-		goto unregister_resource;
+		goto free_labels;
 
 	struct vaccel_arg_array read_args;
 	ret = vaccel_arg_array_init(&read_args, 2);
 	if (ret) {
 		fprintf(stderr, "Could not initialize read args array\n");
-		goto unregister_resource;
+		goto free_labels;
 	}
 
 	struct vaccel_arg_array write_args;
@@ -103,7 +147,7 @@ int main(int argc, char *argv[])
 			goto unregister_resource;
 		}
 
-		printf("detection imagename: %s\n", out_imagename);
+		print_detections(out_imagename, labels, nr_labels);
 	}
 
 release_write_args_array:
@@ -112,6 +156,12 @@ release_write_args_array:
 release_read_args_array:
 	if (vaccel_arg_array_release(&read_args))
 		fprintf(stderr, "Could not release read args array\n");
+free_labels:
+	if (labels) {
+		for (size_t i = 0; i < nr_labels; i++)
+			free(labels[i]);
+		free(labels);
+	}
 unregister_resource:
 	if (model.id > 0 && vaccel_resource_unregister(&model, &sess))
 		fprintf(stderr, "Could not unregister model from session\n");

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -30,7 +30,8 @@ examples_includes = include_directories('.')
 examples = []
 foreach e : examples_sources
   name = fs.stem(e)
-  if name.contains('inference')
+  if name.contains('inference') or name in ['classify', 'classify_generic',
+      'detect', 'detect_generic']
     sources = [e, examples_common_inference_sources,
       examples_common_inference_headers]
   elif name.contains('serialized')


### PR DESCRIPTION
Add an optional `[labels_path]` argument to the classify and detect image inference examples. When provided, the example loads the file via the existing `inference_load_labels()` helper and resolves numeric class IDs in the plugin output to human-readable names before printing. When omitted, output is printed verbatim, preserving backwards compatibility with older plugins that already emit names directly.