### PR TITLE
fix: Dispatch `VACCEL_OP_NOOP` through `vaccel_genop`

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -12,6 +12,7 @@ examples_sources = files([
   'local_and_virtio.c',
   'mbench.c',
   'noop.c',
+  'noop_generic.c',
   'pose.c',
   'pose_generic.c',
   'segment.c',

--- a/examples/noop_generic.c
+++ b/examples/noop_generic.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "vaccel.h"
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	struct vaccel_session sess;
+	struct vaccel_prof_region noop_stats = VACCEL_PROF_REGION_INIT("noop");
+
+	if (argc > 2) {
+		fprintf(stderr, "Usage: %s [iterations]\n", argv[0]);
+		return VACCEL_EINVAL;
+	}
+
+	ret = vaccel_session_init(&sess, 0);
+	if (ret) {
+		fprintf(stderr, "Could not initialize session\n");
+		return ret;
+	}
+
+	printf("Initialized session with id: %" PRId64 "\n", sess.id);
+
+	struct vaccel_arg_array read_args;
+	ret = vaccel_arg_array_init(&read_args, 1);
+	if (ret) {
+		fprintf(stderr, "Could not initialize read args array\n");
+		goto release_session;
+	}
+
+	const uint8_t op_type = (uint8_t)VACCEL_OP_NOOP;
+	ret = vaccel_arg_array_add_uint8(&read_args, (uint8_t *)&op_type);
+	if (ret) {
+		fprintf(stderr, "Failed to pack op_type arg\n");
+		goto release_read_args_array;
+	}
+
+	const int iter = (argc > 1) ? atoi(argv[1]) : 1;
+	for (int i = 0; i < iter; i++) {
+		vaccel_prof_region_start(&noop_stats);
+
+		ret = vaccel_genop(&sess, read_args.args, read_args.count, NULL,
+				   0);
+
+		vaccel_prof_region_stop(&noop_stats);
+
+		if (ret) {
+			fprintf(stderr, "Could not run op: %d\n", ret);
+			goto release_read_args_array;
+		}
+	}
+
+release_read_args_array:
+	if (vaccel_arg_array_release(&read_args))
+		fprintf(stderr, "Could not release read args array\n");
+release_session:
+	if (vaccel_session_release(&sess))
+		fprintf(stderr, "Could not release session\n");
+
+	vaccel_prof_region_print(&noop_stats);
+	vaccel_prof_region_release(&noop_stats);
+
+	return ret;
+}

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -31,6 +31,7 @@ printf "\n$(tput setaf 2)%s$(tput sgr0)\n" \
 	"Running examples with plugin '${VACCEL_PLUGINS}'"
 set -x
 eval "${CONFIG_WRAPPER_CMD}" "${EXAMPLES_DIR}/noop"
+eval "${CONFIG_WRAPPER_CMD}" "${EXAMPLES_DIR}/noop_generic" 1
 eval "${CONFIG_WRAPPER_CMD}" "${EXAMPLES_DIR}/classify" \
 	"${SHARE_DIR}/images/example.jpg" 1
 eval "${CONFIG_WRAPPER_CMD}" "${EXAMPLES_DIR}/classify" \

--- a/src/ops/genop.c
+++ b/src/ops/genop.c
@@ -60,7 +60,7 @@ int vaccel_genop(struct vaccel_session *sess, struct vaccel_arg *read,
 	}
 
 	vaccel_op_type_t op_type = (vaccel_op_type_t)u_op_type;
-	if (!op_type || op_type >= VACCEL_OP_MAX) {
+	if (op_type >= VACCEL_OP_MAX) {
 		vaccel_error("Invalid operation type");
 		return VACCEL_EINVAL;
 	}

--- a/src/ops/noop.c
+++ b/src/ops/noop.c
@@ -42,13 +42,16 @@ int vaccel_noop(struct vaccel_session *sess)
 int vaccel_noop_unpack(struct vaccel_session *sess, struct vaccel_arg *read,
 		       int nr_read, struct vaccel_arg *write, int nr_write)
 {
-	if (nr_read || read) {
+	(void)read;
+	(void)write;
+
+	if (nr_read) {
 		vaccel_error("Wrong number of read arguments for noop: %d",
 			     nr_read);
 		return VACCEL_EINVAL;
 	}
 
-	if (nr_write || write) {
+	if (nr_write) {
 		vaccel_error("Wrong number of write arguments for noop: %d",
 			     nr_write);
 		return VACCEL_EINVAL;

--- a/test/ops/test_noop.cpp
+++ b/test/ops/test_noop.cpp
@@ -9,20 +9,37 @@
 
 #include "vaccel.h"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 
 TEST_CASE("noop", "[ops][noop]")
 {
-	int ret;
 	struct vaccel_session sess;
+	REQUIRE(vaccel_session_init(&sess, 0) == VACCEL_OK);
 
-	ret = vaccel_session_init(&sess, 0);
+	int const ret = vaccel_noop(&sess);
 	REQUIRE(ret == VACCEL_OK);
 
-	ret = vaccel_noop(&sess);
+	REQUIRE(vaccel_session_release(&sess) == VACCEL_OK);
+}
+
+TEST_CASE("noop_generic", "[ops][noop]")
+{
+	struct vaccel_session sess;
+	REQUIRE(vaccel_session_init(&sess, 0) == VACCEL_OK);
+
+	struct vaccel_arg_array read_args;
+	REQUIRE(vaccel_arg_array_init(&read_args, 1) == VACCEL_OK);
+
+	const auto op_type = (uint8_t)VACCEL_OP_NOOP;
+	REQUIRE(vaccel_arg_array_add_uint8(&read_args, (uint8_t *)&op_type) ==
+		VACCEL_OK);
+
+	int const ret = vaccel_genop(&sess, read_args.args, read_args.count,
+				     nullptr, 0);
 	REQUIRE(ret == VACCEL_OK);
 
-	ret = vaccel_session_release(&sess);
-	REQUIRE(ret == VACCEL_OK);
+	REQUIRE(vaccel_session_release(&sess) == VACCEL_OK);
+	REQUIRE(vaccel_arg_array_release(&read_args) == VACCEL_OK);
 }


### PR DESCRIPTION
Make `VACCEL_OP_NOOP` reachable via `vaccel_genop`:
- Stop rejecting `op_type == 0` in `vaccel_genop`, since `VACCEL_OP_NOOP` is defined as 0
- Validate counts only in `vaccel_noop_unpack()`, so non-NULL `read`/`write` pointers with zero count are accepted