### PR TITLE
ci(coverage): Replace per-PR commit with main-driven update PR

### DIFF
--- a/.github/actions/commit-file/action.yml
+++ b/.github/actions/commit-file/action.yml
@@ -60,7 +60,7 @@ runs:
       run: |
         content=$(base64 -w0 "$FILE")
         sha=$(git rev-parse "${BRANCH}:${FILE}")
-        message=$(printf "%s\n\n%s" "$MESSAGE" "$SIGNED_OFF_BY")
+        message=$(printf "%s\n\nSigned-off-by: %s" "$MESSAGE" "$SIGNED_OFF_BY")
 
         gh api "repos/${REPO}/contents/${FILE}" \
           --method PUT \

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -21,6 +21,11 @@ on:
         description: 'Whether to commit the coverage report'
         type: boolean
         default: false
+      create-pr:
+        description: >
+          Whether to create or update a pull request with the coverage report
+        type: boolean
+        default: false
       comment-diff:
         description: >
           Whether to post a pull request comment with the coverage diff
@@ -130,6 +135,7 @@ jobs:
           coverage: 'true'
 
       - name: Checkout default_branch
+        if: inputs.comment-diff == true
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -181,13 +187,15 @@ jobs:
         id: generate-pr-token
         if: >-
           vars.VACCEL_BOT_CLIENT_ID &&
-          (inputs.comment-diff == true || inputs.commit == true)
+          (inputs.comment-diff == true || inputs.commit == true ||
+            inputs.create-pr == true)
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
           private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
           permission-contents: >-
-            ${{ inputs.commit == true && 'write' || 'read' }}
+            ${{ (inputs.commit == true || inputs.create-pr == true)
+              && 'write' || 'read' }}
           permission-pull-requests: write
 
       - name: PR comment with file
@@ -201,7 +209,7 @@ jobs:
 
       - name: Generate markdown file
         id: generate-md-file
-        if: inputs.commit == true
+        if: inputs.commit == true || inputs.create-pr == true
         env:
           REPO_DIR: ${{ steps.set-repo-dirs.outputs.repo }}
           BUILD_TYPE: ${{ matrix.build-type }}
@@ -225,11 +233,49 @@ jobs:
         if: inputs.commit == true
         uses: ./.github/actions/commit-file
         with:
-          workdir: ${{ steps.set-repo-dirs.outputs.repo }} 
-          branch: ${{ github.event.pull_request.head.ref || github.ref_name }} 
+          workdir: ${{ steps.set-repo-dirs.outputs.repo }}
+          branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
           file: ${{ steps.generate-md-file.outputs.coverage-file }}
           message: "docs(coverage): Update coverage report"
           token: ${{ steps.generate-pr-token.outputs.token || github.token }}
+
+      - name: Get committer app info
+        id: get-app-info
+        if: inputs.create-pr == true
+        uses: ./.github/actions/get-github-app-info
+        with:
+          app-slug: ${{ steps.generate-pr-token.outputs.app-slug }}
+
+      - name: Create coverage PR
+        if: inputs.create-pr == true
+        uses: peter-evans/create-pull-request@v8
+        env:
+          COMMITTER: >-
+            ${{ format('{0} <{1}>',
+              steps.get-app-info.outputs.user-login,
+              steps.get-app-info.outputs.user-email) }}
+        with:
+          path: ${{ steps.set-repo-dirs.outputs.repo }}
+          token: >-
+            ${{ steps.generate-pr-token.outputs.token || github.token }}
+          commit-message: |
+            docs(coverage): Update coverage report
+
+            Refresh the coverage report from the latest test run on main
+          committer: ${{ env.COMMITTER }}
+          sign-commits: true
+          signoff: true
+          branch: "docs_update_coverage_report"
+          delete-branch: true
+          title: "docs(coverage): Update coverage report"
+          body: |
+            Refresh the coverage report from the latest test run on main.
+
+            Opened automatically by the `coverage-report` workflow.
+          labels: |
+            coverage
+            ok-to-test
+          add-paths: ${{ steps.generate-md-file.outputs.coverage-file }}
 
       - name: Clean-up
         if: always()

--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -21,6 +21,14 @@ jobs:
       release: true
     secrets: inherit
 
+  generate-coverage:
+    name: Generate Coverage Report
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/coverage-report.yml
+    with:
+      create-pr: true
+    secrets: inherit
+
   update-release:
     needs: build-dist
     name: Update Release

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -15,24 +15,9 @@ concurrency:
 permissions: read-all
 
 jobs:
-  commit-coverage:
-    name: Commit coverage report
-    if: >-
-      github.event.pull_request.base.ref == 'main' &&
-      github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'approved'
-    uses: ./.github/workflows/coverage-report.yml
-    with:
-      commit: true
-    secrets: inherit
-
   check-pr-status:
-    needs: commit-coverage
     name: Check PR status
-    if: >-
-      always() &&
-      github.event.pull_request.base.ref == 'main' &&
-      needs.commit-coverage.result != 'failure'
+    if: github.event.pull_request.base.ref == 'main'
     uses: ./.github/workflows/check-pr-status.yml
     with:
       pr-number: >-


### PR DESCRIPTION
Add a `create-pr` path to the `coverage-report` workflow to open or update a rolling `docs_update_coverage_report` PR with the regenerated report. Use it in a new  `main-build-and-upload` job, so the report refreshes on push to `main`.

Drop the `commit-coverage` job from `pr-trailers`. That job ran on review approval and committed the report directly to the PR branch, which dismissed the same approval under the "dismiss stale reviews" branch protection.